### PR TITLE
Fix THREE is using the global

### DIFF
--- a/src/TPS/AnimationController.js
+++ b/src/TPS/AnimationController.js
@@ -1,3 +1,5 @@
+import { THREE } from '../install.js';
+
 const TURN_DURATION = 200;
 const TAU = 2 * Math.PI;
 const modulo = ( n, d ) => ( ( n % d ) + d ) % d;


### PR DESCRIPTION
When I use `vite` to package the application, I can't find `THREE`.
